### PR TITLE
Fix two "broken" tests

### DIFF
--- a/test/pbkdf2_eqc.erl
+++ b/test/pbkdf2_eqc.erl
@@ -27,7 +27,7 @@ prop_equivalent() ->
 			%% we assume the ebin of this file is in .eunit, where rebar puts it
 			PortSrcDir = filename:dirname(code:which(?MODULE)) ++ "/../test",
 			%% yeeehaw
-			[] = os:cmd("gcc "++PortSrcDir++"/pbkdf2-port.c -o pbkdf2-port -I"++EIDir++"/include -L"++EIDir++"/lib -lei -lssl -lcrypto"),
+			[] = os:cmd("gcc -Wno-format -Wno-pointer-sign  -Wno-implicit-function-declaration "++PortSrcDir++"/pbkdf2-port.c -o pbkdf2-port -I"++EIDir++"/include -L"++EIDir++"/lib -lei -lssl -lcrypto"),
 			?FORALL({Password, Salt, Iterations, KeySize}, {gen_print_bin(), gen_salt(), gen_iterations(), gen_keysize()},
 				begin
 					Port = open_port({spawn, "./pbkdf2-port"}, [{packet, 4}]),

--- a/test/pbkdf2_tests.erl
+++ b/test/pbkdf2_tests.erl
@@ -39,7 +39,7 @@ pbkdf2_hex(Args) ->
 
 rfc6070_correctness_test_() ->
 	[
-		{timeout, 60,
+		{timeout, 60000, % do not trust the docs - timeout is in msec
 			?_assertEqual(
 				Expected,
 				pbkdf2_hex(Args)


### PR DESCRIPTION
On my mac at least (on r16b02-basho9) the test `pbkdf2_eqc` failed to run as it cowboy-compiles a port as part of the test run. However the gcc compilation returned warnings, and so a `badmatch`, and the test failed. This PR includes a commit that ups the cowboy ante by adding 3 `-Wno-xxxx` flags to supress the warnings for the compiler. The test now passes.

Also, another test had an eunit timeout of `60` specified. In this version of erlang at least, the timeout is specified in milliseconds, and 60ms was just not long enough. I assumed the author's intention was for 60 seconds and updated the timeout accordingly. The test now passes.